### PR TITLE
Fix the missing api in config

### DIFF
--- a/lab-5/README.md
+++ b/lab-5/README.md
@@ -145,6 +145,7 @@ kubectl get virtualservice reviews -o yaml
 
 Config:
 ```yaml
+apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: reviews


### PR DESCRIPTION
**Description**

One of the config in lab5 is missing the api line.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
